### PR TITLE
jupyter notebookで対象カーネルを選択可能に修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,5 @@ COPY pyproject.toml poetry.lock poetry.toml $WORKDIR/
 ENV PYTHONPATH "/root/workspace/src:$PYTHONPATH"
 
 RUN poetry install --no-root
+
+RUN python -m ipykernel install --user --name python3.10 --display-name "Python 3.10.12"


### PR DESCRIPTION
## 🔨 変更内容

- コンテナで用いられているpython3.10をjupyter notebookのカーネルとして選択できるように修正した

## 💡 特筆事項

## 📸 スクリーンショット

## ✅ 解決するイシュー

- close #14 

## 🤝 関連するイシュー
